### PR TITLE
feat: add readme and add different api urls to run_lightmem_qwen

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ pip install lightmem  # Coming soon
 ```
 
 ## ⚡ Quick Start
+
+1. Modify the `JUDGE_MODEL`, `LLM_MODEL`, and their respective `API_KEY` and `BASE_URL` in `API Configuration`.
+
+2. Download `LLMLINGUA_MODEL` from [microsoft/llmlingua-2-bert-base-multilingual-cased-meetingbank](https://huggingface.co/microsoft/llmlingua-2-bert-base-multilingual-cased-meetingbank) and `EMBEDDING_MODEL` from [sentence-transformers/all-MiniLM-L6-v2](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2) and modify their paths in `Model Paths`.
+
+3. Download the dataset from [longmemeval-cleaned](https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned), and modidy the path in `Data Configuration`.
+
 ```python
 cd experiments
 python run_lightmem_qwen.py

--- a/experiments/run_lightmem_qwen.py
+++ b/experiments/run_lightmem_qwen.py
@@ -7,10 +7,12 @@ import os
 from lightmem.memory.lightmem import LightMemory
 
 # ============ API Configuration ============
-API_KEY='your_api_key_here'
-API_BASE_URL=''
-LLM_MODEL='qwen3-30b-a3b-instruct-2507'
-JUDGE_MODEL='gpt-4o-mini'
+JUDGE_MODEL_API_KEY='sk-xxxxxxxxxxxxxxxxxxxxxxxxxx'
+JUDGE_MODEL_BASE_URL='https://api.deepseek.com/v1'
+JUDGE_MODEL='deepseek-chat'
+API_KEY='sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+API_BASE_URL='https://dashscope.aliyuncs.com/compatible-mode/v1'
+LLM_MODEL='qwen-plus'
 
 # ============ Model Paths ============
 LLMLINGUA_MODEL_PATH='/your/path/to/models/llmlingua-2-bert-base-multilingual-cased-meetingbank'
@@ -149,7 +151,7 @@ def load_lightmem(collection_name):
     lightmem = LightMemory.from_config(config)
     return lightmem
 
-llm_judge = LLMModel(JUDGE_MODEL, API_KEY, API_BASE_URL)
+llm_judge = LLMModel(JUDGE_MODEL, JUDGE_MODEL_API_KEY, JUDGE_MODEL_BASE_URL)
 llm = LLMModel(LLM_MODEL, API_KEY, API_BASE_URL)
 
 data = json.load(open(DATA_PATH, "r"))


### PR DESCRIPTION
add details for quickstart in readme and add JUDGE_MODEL_API_KEY, JUDGE_MODEL_BASE_URL to the API configuration part in `experiments/run_lightmem_qwen.py`