### PR TITLE
feat(retriever): Add bm25 strategy and fix related init/retrieve bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,4 @@ __marimo__/
 __pycache__/
 *.py[codz]
 *$py.class
+memory_entries.json

--- a/examples/run_lightmem_bm25.py
+++ b/examples/run_lightmem_bm25.py
@@ -1,11 +1,21 @@
-"""
-Example: Demonstrate basic usage of LightMemory with BM25 retrieval.
-This script follows the same structure and annotation style as other examples in LightMem.
-"""
-
 import os
-from lightmem.memory.lightmem import LightMemory
+import sys
+import traceback
 
+src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
+if src_path not in sys.path:
+    sys.path.insert(0, src_path)
+
+try:
+    from lightmem.memory.lightmem import LightMemory
+    from lightmem.configs.base import BaseMemoryConfigs, MemoryManagerConfig
+    from lightmem.configs.retriever.bm25 import BM25Config
+    from lightmem.configs.logging.base import LoggingConfig
+    from lightmem.configs.topic_segmenter.base import TopicSegmenterConfig 
+except ImportError as e:
+    print(f"--- Import failed! Error: {e} ---")
+    print(f"--- Please ensure the 'src' directory is at: {src_path} ---")
+    sys.exit()
 
 # ============ Data Configuration ============
 EXAMPLE_COLLECTION = "demo_collection_bm25"
@@ -13,38 +23,56 @@ EXAMPLE_COLLECTION = "demo_collection_bm25"
 
 def load_lightmem_bm25(collection_name):
     """
-    Load a LightMemory instance configured to use BM25 retrieval.
-    This function mirrors the config structure in other examples.
+    Load a LightMemory instance configured for BM25 retrieval.
     """
-    config = {
-        "pre_compress": False,
-        "topic_segment": False,
-        "index_strategy": "bm25",  # ✅ Use BM25 instead of embedding
-        "retrieve_strategy": "bm25",
-        "bm25_retriever": {
-            "model_name": "bm25",
-            "configs": {
-                "collection_name": collection_name,
-                "path": f"./bm25_data/{collection_name}",
-            },
-        },
-        "memory_manager": {
-            "model_name": "openai",
-            "configs": {
-                "model": "gpt-3.5-turbo",
-                "max_tokens": 2048,
-            }
-        },
-        "logging": {
-            "level": "INFO",
-            "file_enabled": True,
-            "log_dir": "logs",
-            "log_filename_prefix": "example_bm25",
-            "console_enabled": True,
-            "file_level": "DEBUG",
+
+    # 1. Define BM25 retriever configuration
+    bm25_retriever_config = BM25Config(
+        collection_name=collection_name,
+        path=f"./bm25_data/{collection_name}"
+    )
+
+    # 2. Define Memory Manager configuration (requires OPENAI_API_KEY)
+    manager_config = MemoryManagerConfig(
+        model_name="openai",
+        configs={
+            "model": "gpt-3.5-turbo",
+            "max_tokens": 2048,
         }
-    }
-    lightmem = LightMemory.from_config(config)
+    )
+    
+    # 3. Define logging configuration
+    logging_config = LoggingConfig(
+        level="INFO",
+        file_enabled=True,
+        log_dir="logs",
+        log_filename_prefix="example_bm25",
+        console_enabled=True,
+        file_level="DEBUG",
+    )
+
+    # 4. Define segmenter configuration (requires torch/llmlingua-2)
+    segmenter_config = TopicSegmenterConfig(
+        model_name="llmlingua-2" 
+    )
+    
+    # 5. Assemble the final BaseMemoryConfigs
+    config_object = BaseMemoryConfigs(
+        pre_compress=False,
+        topic_segment=True,  # Ensure add_memory does not exit prematurely
+        topic_segmenter=segmenter_config,
+        index_strategy="bm25",
+        retrieve_strategy="bm25",
+        bm25_retriever=bm25_retriever_config,
+        memory_manager=manager_config,
+        logging=logging_config
+    )
+    
+    # 6. Initialize using the config object
+    print("--- Initializing LightMemory (requires API Key and torch)... ---")
+    lightmem = LightMemory.from_config(config_object.model_dump())
+    print("--- LightMemory initialization successful ---")
+    
     return lightmem
 
 
@@ -52,23 +80,39 @@ def main():
     """
     Run a minimal demonstration of LightMemory add/retrieve workflow (BM25 version).
     """
-    print("========== LightMemory BM25 Example ==========")
-    lightmem = load_lightmem_bm25(EXAMPLE_COLLECTION)
+        
+    print("\n========== LightMemory BM25 Example ==========")
+    
+    try:
+        lightmem = load_lightmem_bm25(EXAMPLE_COLLECTION)
 
-    # ============ Add Example Memory ============
-    messages = [
-        {"role": "user", "content": "The capital of France is Paris."},
-        {"role": "assistant", "content": "Correct, Paris is the capital city of France."}
-    ]
-    result = lightmem.add_memory(messages=messages, force_segment=True, force_extract=True)
-    print("Memory added:", result)
+        # ============ Add Example Memory ============
+        print("\n--- Attempting: lightmem.add_memory() ---")
+        
+        session_timestamp = "2025/11/12 (Wed) 19:30" 
+        messages = [
+            {"role": "user", "content": "The capital of France is Paris.", "time_stamp": session_timestamp},
+            {"role": "assistant", "content": "Correct, Paris is the capital city of France.", "time_stamp": session_timestamp}
+        ] 
+        
+        result = lightmem.add_memory(messages=messages, force_segment=True, force_extract=True)
+        print("Memory added:", result)
 
-    # ============ Retrieve Example Memory ============
-    query = "What is the capital of France?"
-    results = lightmem.retrieve(query, limit=5)
-    print("Query:", query)
-    print("Retrieved Results:", results)
-    print("===============================================")
+        # ============ Retrieve Example Memory ============
+        print("\n--- Attempting: lightmem.retrieve() ---")
+        query = "What is the capital of France?"
+        results = lightmem.retrieve(query, limit=5)
+        print("Query:", query)
+        print("Retrieved Results:", results)
+
+    except Exception as e:
+        print(f"\n--- Example run failed ---")
+        print("This may be due to a missing OPENAI_API_KEY environment variable or missing 'torch' dependency.")
+        print(f"Error Type: {type(e)}")
+        print(f"Error Details: {e}")
+        traceback.print_exc()
+        
+    print("\n===============================================")
 
 
 # ============ Entry Point ============

--- a/src/lightmem/configs/base.py
+++ b/src/lightmem/configs/base.py
@@ -9,6 +9,7 @@ from lightmem.configs.text_embedder.base import TextEmbedderConfig
 from lightmem.configs.multimodal_embedder.base import MMEmbedderConfig
 from lightmem.configs.retriever.contextretriever.base import ContextRetrieverConfig
 from lightmem.configs.retriever.embeddingretriever.base import EmbeddingRetrieverConfig
+from lightmem.configs.retriever.bm25 import BM25Config
 from lightmem.configs.logging.base import LoggingConfig
 
 lightmem_dir = ""
@@ -57,7 +58,7 @@ class BaseMemoryConfigs(BaseModel):
     extract_threshold: float = Field(
         default=0.5,
     )
-    index_strategy: Optional[Literal["embedding", "context", "hybrid"]] = Field(
+    index_strategy: Optional[Literal["embedding", "context", "hybrid", "bm25"]] = Field(
         default=None,
         description="Indexing strategy to use. Choices: "
                 "embedding|text|hybrid"
@@ -74,10 +75,9 @@ class BaseMemoryConfigs(BaseModel):
         description="Path to the history database",
         default=os.path.join(lightmem_dir, "history.db"),
     )
-    retrieve_strategy: Optional[Literal["context", "embedding", "hybrid"]] = Field(
-        default="embedding",
-        description="Retrieving strategy to use. Choices: "
-                "embedding|context|hybrid"
+    retrieve_strategy: Optional[Literal["context", "embedding", "hybrid", "bm25"]] = Field(
+    default="embedding",
+    description="Retrieving strategy to use. Choices: 'embedding' | 'context' | 'hybrid' | 'bm25'"
     )
     context_retriever: Optional[ContextRetrieverConfig] = Field(
         description="Configuration for the context-based retriever (active only if retrieve_strategy is 'context' or 'hybrid')",
@@ -86,6 +86,10 @@ class BaseMemoryConfigs(BaseModel):
     embedding_retriever: Optional[EmbeddingRetrieverConfig] = Field(
         description="Configuration for the embedding-based retriever (active only if retrieve_strategy is 'embedding' or 'hybrid')",
         default=None,
+    )
+    bm25_retriever: Optional[BM25Config] = Field(
+    default=None,
+    description="Configuration for BM25 retriever (active only if retrieve_strategy is 'bm25')."
     )
     update: Optional[Literal["online","offline"]] = Field(
         description="'online'=immediate during execution, 'offline'=scheduled updates",

--- a/src/lightmem/configs/memory_manager/base.py
+++ b/src/lightmem/configs/memory_manager/base.py
@@ -12,7 +12,7 @@ class MemoryManagerConfig(BaseModel):
         "ollama",
     ]
 
-    configs: Optional[dict] = Field(description="Configuration for the specific MemoryManager model", default={})
+    configs: Optional[Any] = Field(description="Configuration for the specific MemoryManager model", default={})
 
     @model_validator(mode='before')
     def validate_model_name(cls, values):

--- a/src/lightmem/configs/retriever/bm25.py
+++ b/src/lightmem/configs/retriever/bm25.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, Optional
 class BM25Config(BaseModel):
     """Configuration for BM25 retriever."""
 
+    collection_name: str
+    path: str
     k1: float = Field(1.5, description="BM25 k1 parameter controlling term frequency scaling")
     b: float = Field(0.75, description="BM25 b parameter controlling document length normalization")
     tokenizer: Optional[str] = Field(None, description="Optional tokenizer identifier or function name")


### PR DESCRIPTION
* **examples/run_lightmem_bm25.py**:
    * Added a new example script to test the `bm25` strategy end-to-end.

* **src/lightmem/configs/base.py**:
    * Added `"bm25"` to the `Literal` types for `index_strategy` and `retrieve_strategy` to allow the new config.

* **src/lightmem/configs/memory_manager/base.py**:
    * Fixed a `ValidationError` by changing `configs: Optional[dict]` to `Optional[Any]` to match the validator's logic.

* **src/lightmem/configs/retriever/bm25.py**:
    * Fixed a `ValidationError` by adding the required `collection_name` and `path` fields to `BM25Config`.

* **src/lightmem/memory/lightmem.py**:
    * Replaced the `retrieve` method, which was hardcoded for "embedding", with a new version that correctly checks the `retrieve_strategy` and calls the `context_retriever` for "bm25".
    * Updated `offline_update` to correctly call `index()` when `index_strategy="bm25"`.
    * Fixed multiple `AttributeError`s in `__init__` related to `compressor`, `model_name`, and `text_embedder` to allow non-embedding strategies to initialize correctly.