### PR TITLE
fix: align retrieve return type and callers

### DIFF
--- a/examples/run_lightmem_ollama.py
+++ b/examples/run_lightmem_ollama.py
@@ -243,7 +243,7 @@ def main():
         messages.append({"role": "system", "content": "You are a helpful assistant."})
         messages.append({
             "role": "user",
-            "content": f"Question time:{item['question_date']} and question:{item['question']}\nPlease answer the question based on the following memories: {str(related_memories)}"
+            "content": f"Question time:{item['question_date']} and question:{item['question']}\nPlease answer the question based on the following memories: {'\n'.join(related_memories)}"
         })
         generated_answer = llm.call(messages)
 

--- a/examples/run_lightmem_transformers.py
+++ b/examples/run_lightmem_transformers.py
@@ -255,7 +255,7 @@ def main():
         messages.append({"role": "system", "content": "You are a helpful assistant."})
         messages.append({
             "role": "user",
-            "content": f"Question time:{item['question_date']} and question:{item['question']}\nPlease answer the question based on the following memories: {str(related_memories)}"
+            "content": f"Question time:{item['question_date']} and question:{item['question']}\nPlease answer the question based on the following memories: {'\n'.join(related_memories)}"
         })
         generated_answer = llm.call(messages)
 

--- a/experiments/longmemeval/run_lightmem_gpt.py
+++ b/experiments/longmemeval/run_lightmem_gpt.py
@@ -183,7 +183,7 @@ for item in tqdm(data):
     messages.append({"role": "system", "content": "You are a helpful assistant."})
     messages.append({
         "role": "user",
-        "content": f"Question time:{item['question_date']} and question:{item['question']}\nPlease answer the question based on the following memories: {str(related_memories)}"
+        "content": f"Question time:{item['question_date']} and question:{item['question']}\nPlease answer the question based on the following memories: {'\n'.join(related_memories)}"
     })
     generated_answer = llm.call(messages)
 

--- a/experiments/longmemeval/run_lightmem_qwen.py
+++ b/experiments/longmemeval/run_lightmem_qwen.py
@@ -201,7 +201,7 @@ for item in tqdm(data):
     messages.append({"role": "system", "content": "You are a helpful assistant."})
     messages.append({
         "role": "user",
-        "content": f"Question time:{item['question_date']} and question:{item['question']}\nPlease answer the question based on the following memories: {str(related_memories)}"
+        "content": f"Question time:{item['question_date']} and question:{item['question']}\nPlease answer the question based on the following memories: {'\n'.join(related_memories)}"
     })
     generated_answer = llm.call(messages)
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -247,12 +247,7 @@ def retrieve_memory(query: str, limit: int = 10, filters: Optional[Any] = {}) ->
             limit=limit,
             filters=filters
         )
-        if isinstance(related_memories, str):
-            related_memories_list = [item for item in related_memories.split("\n") if item.strip()]
-        elif isinstance(related_memories, list):
-            related_memories_list = related_memories
-        else:
-            related_memories_list = [str(related_memories)]
+        related_memories_list = related_memories
 
         return {
             "status": STATUS_SUCCESS,

--- a/src/lightmem/memory/lightmem.py
+++ b/src/lightmem/memory/lightmem.py
@@ -657,7 +657,7 @@ class LightMemory:
             return_full=True,
         )
         self.logger.info(f"[{call_id}] Found {len(results)} results")
-        formatted_results = []
+        formatted_results: list[str] = []
         for r in results:
             payload = r.get("payload", {})
             time_stamp = payload.get("time_stamp", "")
@@ -665,11 +665,11 @@ class LightMemory:
             memory = payload.get("memory", "")
             formatted_results.append(f"{time_stamp} {weekday} {memory}")
             
-        result_string = "\n".join(formatted_results)
+        result_string: str = "\n".join(formatted_results)
         self.logger.info(f"[{call_id}] Formatted {len(formatted_results)} results into output string")
         self.logger.debug(f"[{call_id}] Output string length: {len(result_string)} characters")
         self.logger.info(f"========== END {call_id} ==========")
-        return result_string
+        return formatted_results
 
     def get_token_statistics(self):
         embedder_stats = {"total_calls": 0, "total_tokens": None}


### PR DESCRIPTION
Fix retrieve() to actually return list[str] as annotated.
Update callers to use '\n'.join() instead of str().
Behavior unchanged.