### PR TITLE
feat: add BoundMem plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,23 @@ All behaviors of LightMem are controlled via the BaseMemoryConfigs configuration
 | `version`             | `'v1.1'`                                    | str. Configuration/API version. Only change if you know compatibility implications. |
 | `logging`             | `'None'`                                    | dict / object. Configuration for logging enabled. |
 
+**(Option) BoundMem Configuration:**
+
+BoundMem tag fallback is intentionally opt-in and is not enabled by `BaseMemoryConfigs` by default. The following are parameters related to the BoundMem plugin in the main functions, which can be added as needed:
+
+| Function | Parameter / Behavior | Notes |
+| --- | --- | --- |
+| `add_memory()` | `boundmem_tags` | Tags newly created memories before insertion. Accepts a string or tag list. |
+| `retrieve()` | `boundmem_tags` | Filters retrieved memories by overlap with the current tags. |
+| `retrieve()` | `boundmem_drop_untagged` | Keeps untagged legacy memories by default; set `True` to drop them. |
+| `retrieve()` | returned memory text | Internal tag prefixes are stripped before results are returned. |
+| `resolve_tags()` | `strategy="hard"` | Uses caller-provided `hard_tags`. |
+| `resolve_tags()` | `strategy="soft"` | Uses `environment_tag_fn` with `query`, `history`, `known_tags`, and optional `metadata`. |
+| `resolve_tags()` | `known_tags` | Caller-maintained tag list; returned together with newly resolved tags. |
+| `tag_text()` / `strip_tags()` | string-level helpers | Add or remove the internal tag prefix for custom integrations. |
+| `filter_by_tags()` | raw retriever-result helper | Keeps memories with overlapping tags; accepts custom `tag_match_fn`. |
+| Matching rule | default matcher | A memory is kept if it shares at least one tag with current tags. |
+
 ## 🏆 Contributors
 
 <table>

--- a/src/lightmem/memory/lightmem.py
+++ b/src/lightmem/memory/lightmem.py
@@ -18,7 +18,7 @@ from lightmem.factory.retriever.embeddingretriever.factory import EmbeddingRetri
 from lightmem.factory.retriever.embeddingretriever.qdrant import QdrantConfig
 from lightmem.factory.memory_buffer.sensory_memory import SenMemBufferManager
 from lightmem.factory.memory_buffer.short_term_memory import ShortMemBufferManager
-from lightmem.memory.utils import MemoryEntry, assign_sequence_numbers_with_timestamps, save_memory_entries,convert_extraction_results_to_memory_entries,normalize_extraction_prompts,process_extraction_results
+from lightmem.memory.utils import *
 from lightmem.memory.prompts import METADATA_GENERATE_PROMPT, UPDATE_PROMPT
 from lightmem.configs.logging.utils import get_logger
 
@@ -207,7 +207,8 @@ class LightMemory:
         METADATA_GENERATE_PROMPT: Optional[Union[str, Dict[str, str]]] = None,
         *,
         force_segment: bool = False, 
-        force_extract: bool = False
+        force_extract: bool = False,
+        boundmem_tags: Optional[Any] = None,
     ):
         """
         Add new memory entries from message history.
@@ -236,6 +237,7 @@ class LightMemory:
                 - None: Use default prompts based on self.config.extraction_mode
             force_segment (bool, optional): If True, forces segmentation regardless of buffer conditions.
             force_extract (bool, optional): If True, forces memory extraction even if thresholds are not met.
+            boundmem_tags (optional): If provided, these tags will be applied to the created MemoryEntry objects for BAM tag-based filtering during retrieval.
 
         Returns:
             dict: A dictionary containing the intermediate results of the memory addition pipeline.
@@ -368,6 +370,12 @@ class LightMemory:
             logger=self.logger
         )
         self.logger.info(f"[{call_id}] Created {len(memory_entries)} MemoryEntry objects")
+        if boundmem_tags is not None:
+            boundmem_tags, _ = resolve_tags(strategy="hard", hard_tags=boundmem_tags)
+            for mem in memory_entries:
+                mem.bam_tags = list(boundmem_tags)
+                mem.memory = tag_text(mem.memory, mem.bam_tags)
+            self.logger.info(f"[{call_id}] Applied BoundMem tags to {len(memory_entries)} MemoryEntry objects")
         for i, mem in enumerate(memory_entries):
             self.logger.debug(f"[{call_id}] MemoryEntry[{i}]: time={mem.time_stamp}, weekday={mem.weekday}, speaker_id={mem.speaker_id}, speaker_name={mem.speaker_name}, topic_id={mem.topic_id}, memory={mem.memory}")
 
@@ -400,7 +408,9 @@ class LightMemory:
             inserted_count = 0
             self.logger.info(f"[{call_id}] Starting embedding and insertion to vector database")
             for mem_obj in memory_list:
-                embedding_vector = self.text_embedder.embed(mem_obj.memory)
+                bam_tags = getattr(mem_obj, "bam_tags", [])
+                embed_text = strip_tags(mem_obj.memory) if bam_tags else mem_obj.memory
+                embedding_vector = self.text_embedder.embed(embed_text)
                 ids = mem_obj.id
                 while self.embedding_retriever.exists(ids):
                     ids = str(uuid.uuid4())
@@ -421,6 +431,8 @@ class LightMemory:
                     "speaker_name": mem_obj.speaker_name,
                     "consolidated": mem_obj.consolidated,
                 }
+                if bam_tags:
+                    payload["bam_tags"] = bam_tags
                 self.embedding_retriever.insert(
                     vectors = [embedding_vector],
                     payloads = [payload],
@@ -629,7 +641,15 @@ class LightMemory:
         )
         self.logger.info(f"========== END {call_id} ==========")
     
-    def retrieve(self, query: str, limit: int = 10, filters: Optional[dict] = None) -> list[str]:
+    def retrieve(
+        self,
+        query: str,
+        limit: int = 10,
+        filters: Optional[dict] = None,
+        *,
+        boundmem_tags: Optional[Any] = None,
+        boundmem_drop_untagged: bool = False,
+    ) -> list[str]:
         """
         Retrieve relevant entries and return them as formatted strings.
 
@@ -637,6 +657,8 @@ class LightMemory:
             query (str): The natural language query string.
             limit (int, optional): Number of results to return. Defaults to 10.
             filters (dict, optional): Optional filters to narrow down the search. Defaults to None.
+            boundmem_tags (optional): If provided, these tags will be used to filter results based on BoundMem tag matching.
+            boundmem_drop_untagged (bool): If True, entries without any BAM tags will be dropped when boundmem_tags is provided.
 
         Returns:
             list[str]: A list of formatted strings containing time_stamp, weekday, and memory.
@@ -657,12 +679,25 @@ class LightMemory:
             return_full=True,
         )
         self.logger.info(f"[{call_id}] Found {len(results)} results")
+        if boundmem_tags is not None:
+            results, boundmem_result = filter_by_tags(
+                query=query,
+                results=results,
+                environment_tags=boundmem_tags,
+                drop_untagged_on_tag_filter=boundmem_drop_untagged,
+            )
+            self.logger.info(
+                f"[{call_id}] BoundMem filter kept {len(results)} results; "
+                f"status={boundmem_result.get('status')}"
+            )
         formatted_results: list[str] = []
         for r in results:
             payload = r.get("payload", {})
             time_stamp = payload.get("time_stamp", "")
             weekday = payload.get("weekday", "")
             memory = payload.get("memory", "")
+            if boundmem_tags is not None:
+                memory = strip_tags(memory)
             formatted_results.append(f"{time_stamp} {weekday} {memory}")
             
         result_string: str = "\n".join(formatted_results)

--- a/src/lightmem/memory/utils.py
+++ b/src/lightmem/memory/utils.py
@@ -2,7 +2,7 @@ import os
 import re
 import json
 from datetime import datetime
-from typing import List, Dict, Literal, Optional, Any, Tuple, Union
+from typing import List, Dict, Literal, Optional, Any, Tuple, Union, Callable
 import tiktoken
 import uuid
 from dataclasses import dataclass, field
@@ -29,6 +29,7 @@ class MemoryEntry:
     hit_time: int = 0
     update_queue: List = field(default_factory=list)
     consolidated: bool = False
+    bam_tags: List[Any] = field(default_factory=list)
     
 def clean_response(response: str) -> List[Dict[str, Any]]:
     """
@@ -135,7 +136,7 @@ def assign_sequence_numbers_with_timestamps(extract_list, offset_ms: int = 500, 
 # TODO：merge into context retriever
 def save_memory_entries(memory_entries, file_path="memory_entries.json"):
     def entry_to_dict(entry):
-        return {
+        data = {
             "id": entry.id,
             "time_stamp": entry.time_stamp,
             "topic_id": entry.topic_id,
@@ -154,6 +155,9 @@ def save_memory_entries(memory_entries, file_path="memory_entries.json"):
             "speaker_name": getattr(entry, "speaker_name", ""),  
             "consolidated": getattr(entry, "consolidated", False),  
         }
+        if getattr(entry, "bam_tags", []):
+            data["bam_tags"] = entry.bam_tags
+        return data
 
     if os.path.exists(file_path):
         with open(file_path, "r", encoding="utf-8") as f:
@@ -748,3 +752,215 @@ def build_empty_result(process_all: bool, has_more: bool = False) -> Dict:
             "time_range": None,
             "has_more": has_more
         }
+
+
+# === BoundMem tag utils ===
+
+def _tags(tags: Optional[Any]) -> List[Any]:
+    """Convert strings, dicts, scalars, or nested containers into a flat tag list."""
+    if tags is None:
+        return []
+    if isinstance(tags, str):
+        return [tags] if tags else []
+    if isinstance(tags, dict):
+        if "tags" in tags or "tag" in tags:
+            return _tags(tags.get("tags", tags.get("tag")))
+        return [tags]
+    if not isinstance(tags, (list, tuple, set)):
+        return [tags]
+    normalized: List[Any] = []
+    for tag in tags:
+        normalized.extend(_tags(tag))
+    return normalized
+
+
+BAM_TAG_PREFIX = "[[BAM_TAGS:"
+BAM_TAG_SUFFIX = "]]"
+
+def _split_tags(content: str) -> Tuple[List[Any], str]:
+    """Split one memory string into BoundMem prefix tags and clean memory text."""
+    if not isinstance(content, str) or not content.startswith(BAM_TAG_PREFIX):
+        return [], content
+    payload_start = len(BAM_TAG_PREFIX)
+    try:
+        tags, consumed = json.JSONDecoder().raw_decode(content[payload_start:])
+    except json.JSONDecodeError:
+        return [], content
+    end = payload_start + consumed
+    if not content.startswith(BAM_TAG_SUFFIX, end):
+        return [], content
+    end += len(BAM_TAG_SUFFIX)
+    after = content[end:]
+    after = after[2:] if after.startswith("\r\n") else after[1:] if after.startswith(("\n", "\r")) else after
+    return _tags(tags), after
+
+
+def resolve_tags(
+    *,
+    query: str = "",
+    history: Optional[List[Any]] = None,
+    hard_tags: Optional[Any] = None,
+    environment_tag_fn: Optional[Callable[[Dict[str, Any]], Any]] = None,
+    known_tags: Optional[List[Any]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    strategy: Literal["hard", "soft"] = "hard",
+) -> Tuple[List[Any], List[Any]]:
+    """
+    Resolve current environment tags and return the updated known-tag list.
+
+    `strategy="hard"` uses only `hard_tags`; `strategy="soft"` requires
+    `environment_tag_fn`, which receives the current query, history, known tags,
+    metadata, and strategy, then returns tags or a dict with `tags` / `tag` and
+    optionally `known_tags`.
+    """
+    if strategy not in ("hard", "soft"):
+        raise ValueError("strategy must be 'hard' or 'soft'")
+    known = _tags(known_tags)
+    if strategy == "hard":
+        if hard_tags is None:
+            raise ValueError("hard_tags is required when strategy='hard'")
+        env_tags = _tags(hard_tags)
+        extra_known = []
+    else:
+        if environment_tag_fn is None:
+            raise ValueError("environment_tag_fn is required when strategy='soft'")
+        raw = environment_tag_fn({
+            "query": query,
+            "history": history or [],
+            "known_tags": list(known),
+            "metadata": metadata or {},
+            "strategy": strategy,
+            "mode": strategy,
+        })
+        env_tags = _tags(raw.get("tags") or raw.get("tag")) if isinstance(raw, dict) else _tags(raw)
+        extra_known = _tags(raw.get("known_tags")) if isinstance(raw, dict) else []
+
+    merged, seen = [], set()
+    for tag in known + extra_known + env_tags:
+        if isinstance(tag, str):
+            key = tag.strip().lower()
+        else:
+            try:
+                key = json.dumps(tag, sort_keys=True, ensure_ascii=False, separators=(",", ":")).lower()
+            except TypeError:
+                key = str(tag).strip().lower()
+        if key and key not in seen:
+            seen.add(key)
+            merged.append(tag)
+    return env_tags, merged
+
+
+def tag_text(content: str, tags: Any) -> str:
+    """Prefix one memory string with tags in a JSON form that can be stripped later."""
+    env_tags = _tags(tags)
+    if not env_tags:
+        return content
+    _, clean = _split_tags(content)
+    encoded = json.dumps(env_tags, ensure_ascii=False, separators=(",", ":"))
+    return f"{BAM_TAG_PREFIX}{encoded}{BAM_TAG_SUFFIX}\n{clean}"
+
+
+def strip_tags(content: str) -> str:
+    """Remove the BoundMem prefix and return the original memory text."""
+    return _split_tags(content)[1]
+
+
+def match_tags(
+    memory_tags: Any,
+    environment_tags: Any,
+    *,
+    tag_match_fn: Optional[Callable[[Dict[str, Any]], Any]] = None,
+    tag_match_threshold: float = 1.0,
+) -> float:
+    """
+    Return a 0-1 score for whether memory tags belong to the current environment.
+
+    By default, any overlap means the memory belongs to the current environment.
+    A custom `tag_match_fn` can override this rule and return bool or a numeric
+    environment-membership score.
+    """
+    mem_tags, env_tags = _tags(memory_tags), _tags(environment_tags)
+    if not env_tags:
+        return 0.0
+    if tag_match_fn is not None:
+        score = tag_match_fn({"memory_tags": mem_tags, "environment_tags": env_tags, "threshold": tag_match_threshold})
+        return 1.0 if score is True else 0.0 if score is False else max(0.0, min(1.0, float(score)))
+    mem_keys, env_keys = set(), set()
+    for group, keys in ((mem_tags, mem_keys), (env_tags, env_keys)):
+        for tag in group:
+            if isinstance(tag, str):
+                key = tag.strip().lower()
+            else:
+                try:
+                    key = json.dumps(tag, sort_keys=True, ensure_ascii=False, separators=(",", ":")).lower()
+                except TypeError:
+                    key = str(tag).strip().lower()
+            if key:
+                keys.add(key)
+    mem_keys.discard("")
+    env_keys.discard("")
+    return 1.0 if mem_keys and env_keys and mem_keys & env_keys else 0.0
+
+
+def filter_by_tags(
+    *,
+    results: List[Dict[str, Any]],
+    environment_tags: Optional[Any] = None,
+    query: str = "",
+    force_drop_all: bool = False,
+    force_allow_all: bool = False,
+    tag_match_fn: Optional[Callable[[Dict[str, Any]], Any]] = None,
+    tag_match_threshold: float = 1.0,
+    drop_untagged_on_tag_filter: bool = False,
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """
+    Keep only retrieved memories whose tags match the current environment.
+
+    The returned results are shallow copies with the memory text stripped back to
+    its original form. `drop_untagged_on_tag_filter=False` lets old untagged
+    memories pass during migration; by default, untagged results are kept for
+    backward compatibility.
+    With the default matcher, scores are binary: `1.0` means at least one tag
+    overlaps, not vector similarity.
+    """
+    if force_drop_all and force_allow_all:
+        raise ValueError("force_drop_all and force_allow_all cannot both be True")
+    env_tags = _tags(environment_tags)
+    scores: List[Optional[float]] = [None] * len(results)
+    if force_drop_all:
+        kept_indices, status = [], "tag_forced_drop_all"
+    elif force_allow_all or not env_tags:
+        kept_indices = list(range(len(results)))
+        status = "tag_forced_allow_all" if force_allow_all else "tag_filter_skipped"
+    else:
+        kept_indices, status = [], "tag_filtered"
+        for idx, result in enumerate(results):
+            payload = result.get("payload", {})
+            prefix_tags, _ = _split_tags(payload.get("memory", ""))
+            memory_tags = prefix_tags + _tags(payload.get("bam_tags"))
+            if not memory_tags:
+                scores[idx] = 0.0 if drop_untagged_on_tag_filter else 1.0
+            else:
+                scores[idx] = match_tags(
+                    memory_tags,
+                    env_tags,
+                    tag_match_fn=tag_match_fn,
+                    tag_match_threshold=tag_match_threshold,
+                )
+            if scores[idx] >= tag_match_threshold:
+                kept_indices.append(idx)
+    kept_results = []
+    for idx in kept_indices:
+        clean = dict(results[idx])
+        payload = dict(clean.get("payload", {}))
+        payload["memory"] = strip_tags(payload.get("memory", ""))
+        clean["payload"] = payload
+        kept_results.append(clean)
+    return kept_results, {
+        "status": status,
+        "environment_tags": env_tags,
+        "tag_scores": scores,
+        "tag_kept_indices": kept_indices,
+        "kept_result_indices": kept_indices,
+        "diagnostics": {"query": query, "drop_untagged_on_tag_filter": drop_untagged_on_tag_filter},
+    }


### PR DESCRIPTION
**This update is fully backward compatible.** BoundMem is disabled by default. Advanced users can generate environment tags when adding and retrieving memories to use tag-based fallback filtering.