### PR TITLE
docs(longmemeval): clarify script selection and document messages_use config

### DIFF
--- a/experiments/longmemeval/readme.md
+++ b/experiments/longmemeval/readme.md
@@ -21,11 +21,19 @@ This script performs the complete evaluation pipeline:
 
 1. Configure your `api_key` and `base_url` inside the script.
 2. Ensure the `longmemeval_s.json` dataset is in the correct path.
-3. Execute the following command:
+3. Execute the command for your LLM provider:
 
-```bash
-python run_lightmem_gpt.py
-```
+   **For OpenAI / GPT-compatible APIs:**
+   ```bash
+   python run_lightmem_gpt.py
+   ```
+
+   **For Qwen / DeepSeek / other OpenAI-compatible APIs:**
+   ```bash
+   python run_lightmem_qwen.py
+   ```
+
+   Both scripts implement the same evaluation pipeline; the only difference is the model provider and API configuration. The root `README.md` Quick Start uses `run_lightmem_qwen.py` as the default example.
 
 ### 2. Offline Memory Update
 
@@ -39,6 +47,22 @@ This utility script demonstrates LightMem's Offline Update mechanism. It process
 ```bash
 python offline_update.py
 ```
+
+## Key Configuration Parameters
+
+Both evaluation scripts share a common configuration block. The parameters below are frequently asked about:
+
+### `messages_use`
+
+Controls which side of each conversation turn is indexed into memory.
+
+| Value | Behavior |
+|---|---|
+| `"user_only"` | Index only user messages (**default** in both scripts; used for the LongMemEval results reported in Table 2 of the paper) |
+| `"assistant_only"` | Index only assistant (model) messages |
+| `"hybrid"` | Index both user and assistant messages per turn |
+
+> **Note on paper Section 3.2**: The paper describes memory entries as containing `{user_i, model_i}` pairs to illustrate the *source data structure*, but the actual experiment configuration uses `"user_only"` for indexing. The `messages_use` option lets you reproduce the exact reported results or experiment with alternative indexing strategies.
 
 ## Results
 Detailed experimental results, including comparisons with baselines and ablation studies on LongMemEval, are available in our research paper:


### PR DESCRIPTION
## Summary

Fixes two documentation gaps in `experiments/longmemeval/readme.md`.

### 1. Missing `run_lightmem_qwen.py` in Quick Start

The `experiments/longmemeval/readme.md` Quick Start (Step 3) only listed:
```bash
python run_lightmem_gpt.py
```

However, the root `README.md` Quick Start recommends:
```bash
cd experiments
python run_lightmem_qwen.py
```

Both scripts exist and both implement the same LongMemEval evaluation pipeline — the only difference is which LLM provider they're configured for. Users following the longmemeval readme were unaware that a Qwen/DeepSeek-compatible alternative existed, causing confusion when the root README pointed to a different script.

**Fix:** Step 3 now lists both scripts with clear provider labels, and notes that the root `README.md` uses `run_lightmem_qwen.py` as its default example.

### 2. Undocumented `messages_use` configuration option (closes #70)

Both evaluation scripts hard-code `"messages_use": "user_only"` in their configuration block. The paper (Section 3.2) describes memory entries as containing `{user_i, model_i}` pairs, which led to the question in issue #70: which setting was actually used for the reported LongMemEval results in Table 2?

**Fix:** Added a *Key Configuration Parameters* section documenting all three values:

| Value | Behavior |
|---|---|
| `"user_only"` | Index only user messages (**default**; used for Table 2 results) |
| `"assistant_only"` | Index only assistant messages |
| `"hybrid"` | Index both user and assistant messages per turn |

A short note clarifies the apparent discrepancy between the paper's description and the script default.

## Type of change

- [x] Documentation improvement

## Checklist

- [x] No notebook or code changes
- [x] No API keys or secrets introduced
- [x] Verified both `run_lightmem_gpt.py` and `run_lightmem_qwen.py` exist in the directory and both use `messages_use: "user_only"`