### PR TITLE
fix: make entropy_compress backend constructible

### DIFF
--- a/src/lightmem/configs/pre_compressor/base.py
+++ b/src/lightmem/configs/pre_compressor/base.py
@@ -10,7 +10,7 @@ class PreCompressorConfig(BaseModel):
 
     _model_configs: ClassVar[Dict[str, str]] = {
         "llmlingua-2": "lightmem.configs.pre_compressor.llmlingua_2.LlmLingua2Config",  
-        "entropy_compress": "lightmem.configs.pre_compressor.entropy_compress.EntropyCompressor"
+        "entropy_compress": "lightmem.configs.pre_compressor.entropy_compress.EntropyCompressorConfig"
     }
 
     configs: Dict[str, Any] = Field(

--- a/src/lightmem/factory/pre_compressor/factory.py
+++ b/src/lightmem/factory/pre_compressor/factory.py
@@ -5,7 +5,7 @@ from lightmem.configs.pre_compressor.base import PreCompressorConfig
 class PreCompressorFactory:
     _MODEL_MAPPING: Dict[str, str] = {
         "llmlingua-2": "lightmem.factory.pre_compressor.llmlingua_2.LlmLingua2Compressor",
-        "entropy_compress": "lightmem.factory.pre_compressor.entropy_compress.",
+        "entropy_compress": "lightmem.factory.pre_compressor.entropy_compress.EntropyCompressor",
     }
 
     @classmethod

--- a/tests/test_pre_compressor_factory.py
+++ b/tests/test_pre_compressor_factory.py
@@ -1,0 +1,37 @@
+from types import SimpleNamespace
+
+from lightmem.configs.pre_compressor.base import PreCompressorConfig
+from lightmem.configs.pre_compressor.entropy_compress import EntropyCompressorConfig
+from lightmem.factory.pre_compressor.factory import PreCompressorFactory
+
+
+def test_entropy_compressor_config_resolves_to_its_config_class():
+    config = PreCompressorConfig(model_name="entropy_compress")
+
+    assert isinstance(config.configs, EntropyCompressorConfig)
+
+
+def test_entropy_compressor_factory_resolves_to_its_implementation(monkeypatch):
+    compressor_config = object()
+    imported = {}
+
+    class FakeEntropyCompressor:
+        def __init__(self, config=None):
+            self.config = config
+
+    def fake_import_module(module_path):
+        imported["module_path"] = module_path
+        return SimpleNamespace(EntropyCompressor=FakeEntropyCompressor)
+
+    monkeypatch.setattr(
+        "lightmem.factory.pre_compressor.factory.import_module",
+        fake_import_module,
+    )
+
+    compressor = PreCompressorFactory.from_config(
+        SimpleNamespace(model_name="entropy_compress", configs=compressor_config)
+    )
+
+    assert imported["module_path"] == "lightmem.factory.pre_compressor.entropy_compress"
+    assert isinstance(compressor, FakeEntropyCompressor)
+    assert compressor.config is compressor_config


### PR DESCRIPTION
## What was broken

`entropy_compress` is listed as a supported pre-compressor, but selecting it fails during config validation, before the model is loaded. The config registry points to `EntropyCompressor` instead of `EntropyCompressorConfig`, and the factory registry ends at the module name without an implementation class.

## What changed

- point the config registry at `EntropyCompressorConfig`
- point the factory registry at `EntropyCompressor`
- add regression tests for both resolution steps without downloading a model

## Test

```bash
PYTHONPATH=src uv run --no-project --python 3.11 \
  --with pytest --with numpy --with 'pydantic>=2.12,<3' \
  python -m pytest -q tests
```

Result: `4 passed`.
