### PR TITLE
fix: allow topic segmentation without precompression

### DIFF
--- a/src/lightmem/memory/lightmem.py
+++ b/src/lightmem/memory/lightmem.py
@@ -161,6 +161,7 @@ class LightMemory:
         self.logger.info("Token statistics tracking initialized")
         
         self.config = config
+        self.compressor = None
         if self.config.pre_compress:
             self.logger.info("Initializing pre-compressor")
             self.compressor = PreCompressorFactory.from_config(self.config.pre_compressor)

--- a/tests/test_lightmemory_initialization.py
+++ b/tests/test_lightmemory_initialization.py
@@ -1,0 +1,41 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from lightmem.configs.base import BaseMemoryConfigs
+from lightmem.memory.lightmem import LightMemory
+
+
+def test_topic_segmentation_initializes_without_precompressor():
+    config = BaseMemoryConfigs(
+        pre_compress=False,
+        topic_segment=True,
+        topic_segmenter={"model_name": "llmlingua-2", "configs": {}},
+        index_strategy="embedding",
+        text_embedder={"model_name": "huggingface", "configs": {}},
+        retrieve_strategy=None,
+    )
+    segmenter = SimpleNamespace(buffer_len=16, tokenizer=object())
+    manager = SimpleNamespace(
+        tokenizer=object(),
+        config=SimpleNamespace(model="gpt-4o-mini"),
+    )
+
+    with (
+        patch(
+            "lightmem.memory.lightmem.TopicSegmenterFactory.from_config",
+            return_value=segmenter,
+        ) as create_segmenter,
+        patch(
+            "lightmem.memory.lightmem.MemoryManagerFactory.from_config",
+            return_value=manager,
+        ),
+        patch(
+            "lightmem.memory.lightmem.TextEmbedderFactory.from_config",
+            return_value=object(),
+        ),
+    ):
+        memory = LightMemory(config)
+
+    assert memory.compressor is None
+    assert memory.segmenter is segmenter
+    create_segmenter.assert_called_once_with(config.topic_segmenter, False, None)


### PR DESCRIPTION
## What broke

`pre_compress` and `topic_segment` are documented as independent options, but enabling topic segmentation without pre-compression crashes during `LightMemory` initialization because `self.compressor` is only assigned inside the pre-compression branch and then passed unconditionally to the segmenter factory.

## Fix

Initialize the optional compressor to `None`; when pre-compression is enabled, the real compressor still replaces it. Topic segmentation can then initialize normally without pre-compression.

## Test

```bash
uv sync --extra dev
uv run --project . python -m pytest -q tests/test_lightmemory_initialization.py tests/test_sensory_memory.py
```

Result: `3 passed`.